### PR TITLE
Cascade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ sudo: false
 node_js:
   - 5
 install:
-  - npm install bower -g
+  - npm install bower gulp -g
   - npm install
   - bower install
 script:
-  - npm run build
+  - gulp make --psc-rts-flags -N1

--- a/bower.json
+++ b/bower.json
@@ -22,14 +22,16 @@
     "output"
   ],
   "dependencies": {
-    "purescript-css": "~0.6.0",
-    "purescript-halogen-css": "~0.2.2",
-    "purescript-halogen": "~0.5.16",
-    "purescript-either": "~0.2.3",
-    "purescript-profunctor-lenses": "~0.4.2",
-    "purescript-random": "~0.2.3"
+    "purescript-css": "^0.6.0",
+    "purescript-halogen-css": "^0.2.2",
+    "purescript-halogen": "^0.5.16",
+    "purescript-either": "^0.2.3",
+    "purescript-profunctor-lenses": "^0.4.2",
+    "purescript-random": "^0.2.3",
+    "purescript-sets": "^0.5.7",
+    "purescript-halogen-bootstrap": "^0.4.0"
   },
   "resolutions": {
-    "purescript-css": "~0.6.0"
+    "purescript-css": "^0.6.0"
   }
 }

--- a/docs/SlamData/Halogen/Select/Cascade/Component.md
+++ b/docs/SlamData/Halogen/Select/Cascade/Component.md
@@ -1,0 +1,58 @@
+## Module SlamData.Halogen.Select.Cascade.Component
+
+#### `SelectKey`
+
+``` purescript
+newtype SelectKey
+  = SelectKey String
+```
+
+##### Instances
+``` purescript
+Eq SelectKey
+Ord SelectKey
+Show SelectKey
+```
+
+#### `Option`
+
+``` purescript
+newtype Option v
+  = Option { key :: SelectKey, value :: v }
+```
+
+##### Instances
+``` purescript
+Eq (Option v)
+Ord (Option v)
+(Show v) => Show (Option v)
+```
+
+#### `State`
+
+``` purescript
+type State v = { options :: Set (Option v), selected :: Map Int (Option v), keyMap :: Map SelectKey (Option v) }
+```
+
+#### `initialState`
+
+``` purescript
+initialState :: forall v. Array v -> (v -> SelectKey) -> State v
+```
+
+#### `Query`
+
+``` purescript
+data Query v a
+  = Selected Int String a
+  | Remove Int a
+  | GetSelected (Array v -> a)
+```
+
+#### `cascadeSelect`
+
+``` purescript
+cascadeSelect :: forall v e. CascadeSelectConfig -> Component (State v) (Query v) (Aff e)
+```
+
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var gulp = require("gulp"),
+    purescript = require("gulp-purescript");
+
+var sources = [
+    "src/**/*.purs",
+    "bower_components/purescript-*/src/**/*.purs"
+];
+
+var foreigns = [
+    "src/**/*.js",
+    "bower_components/purescript-*/src/**/*.js"
+];
+
+gulp.task("make", function() {
+    return purescript.psc({
+        src: sources,
+        ffi: foreigns
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-    "private": true,
-    "scripts": {
-        "build": "pulp build"
-    },
-    "devDependencies": {
-        "pulp": "^8.0.0",
-        "purescript": "^0.7.6"
-    }
+  "private": true,
+  "scripts": {
+    "build": "gulp make"
+  },
+  "devDependencies": {
+    "purescript": "^0.7.6",
+    "gulp": "^3.9.1",
+    "gulp-purescript": "^0.8.0"
+  }
 }

--- a/src/SlamData/Halogen/Select/Cascade/Component.purs
+++ b/src/SlamData/Halogen/Select/Cascade/Component.purs
@@ -1,0 +1,225 @@
+module SlamData.Halogen.Select.Cascade.Component
+  (
+    cascadeSelect
+  , Query(..)
+  , State()
+  , Option(..)
+  , SelectKey(..)
+  , initialState
+  ) where
+
+import Prelude
+
+import Control.Monad.Aff (Aff())
+import Control.MonadPlus (guard)
+
+import Data.Functor (($>))
+import Data.Lens (LensP(), lens, (%~))
+import Data.Foldable as F
+import Data.Map as Map
+import Data.Tuple as Tpl
+import Data.Maybe as M
+import Data.Set as Set
+import Data.List as L
+
+import Halogen hiding (Prop())
+import Halogen.HTML.Core (className, ClassName())
+import Halogen.HTML.Indexed as H
+import Halogen.HTML.Events.Indexed as E
+import Halogen.HTML.Properties.Indexed as P
+import Halogen.Themes.Bootstrap3 as B
+
+cascadeFormClass :: ClassName
+cascadeFormClass = className "cascade-form"
+
+cascadeNewSelectClass :: ClassName
+cascadeNewSelectClass = className "cascade-new-select"
+
+cascadeSelectClass :: ClassName
+cascadeSelectClass = className "cascade-select"
+
+newtype SelectKey = SelectKey String
+runSelectKey :: SelectKey -> String
+runSelectKey (SelectKey s) = s
+
+instance eqSelectKey :: Eq SelectKey where
+  eq (SelectKey s) (SelectKey s') = s == s'
+
+instance ordSelectKey :: Ord SelectKey where
+  compare (SelectKey s) (SelectKey s') = compare s s'
+
+instance showSelectkey :: Show SelectKey where
+  show (SelectKey s) = "(SelectKey " <> s <> ")"
+
+newtype Option v =
+  Option { key :: SelectKey
+         , value :: v
+         }
+
+runOption :: forall v. Option v -> { key :: SelectKey, value :: v }
+runOption (Option r) = r
+
+instance eqOption :: Eq (Option v) where
+  eq (Option {key = k}) (Option {key = k'}) = k == k'
+
+instance ordOption :: Ord (Option v) where
+  compare (Option {key = k}) (Option {key = k'}) = compare k k'
+
+instance showOption :: (Show v) => Show (Option v) where
+  show (Option {key, value}) =
+    "Option {key = " <> show key <> ", value = " <> show value <> "}"
+
+type State v =
+  {
+    options :: Set.Set (Option v)
+  , selected :: Map.Map Int (Option v)
+  , keyMap :: Map.Map SelectKey (Option v)
+  }
+
+_options :: forall a r. LensP {options :: a|r} a
+_options = lens _.options _{options = _}
+
+_selected :: forall a r. LensP {selected :: a|r} a
+_selected = lens _.selected _{selected = _}
+
+initialState :: forall v. Array v -> (v -> SelectKey) -> State v
+initialState vs mkKey =
+  {
+    selected: Map.empty
+  , options: Set.fromFoldable opts
+  , keyMap: Map.fromFoldable $ map optToTuple opts
+  }
+  where
+  mkOpt :: v -> Option v
+  mkOpt v = Option {value: v, key: mkKey v}
+
+  opts :: Array (Option v)
+  opts = map mkOpt vs
+
+  optToTuple :: Option v -> Tpl.Tuple SelectKey (Option v)
+  optToTuple opt@(Option {key}) = Tpl.Tuple key opt
+
+data Query v a
+  = Selected Int String a
+  | Remove Int a
+  | GetSelected (Array v -> a)
+
+type CascadeSelectDSL v e = ComponentDSL (State v) (Query v) (Aff e)
+
+type CascadeSelectConfig =
+  {
+    inviteMessage :: String
+  }
+
+cascadeSelect
+  :: forall v e
+   . CascadeSelectConfig
+  -> Component (State v) (Query v) (Aff e)
+cascadeSelect cfg = component (render cfg) eval
+
+type RenderAccum v =
+  {
+    selectable :: Set.Set (Option v)
+  , html :: Array (ComponentHTML (Query v))
+  }
+
+initialAccum :: forall v. State v -> RenderAccum v
+initialAccum state =
+  {
+    selectable: state.options
+  , html: [ ]
+  }
+
+
+render
+  :: forall v
+   . CascadeSelectConfig
+  -> State v
+  -> ComponentHTML (Query v)
+render cfg state =
+  H.form [ P.classes [ cascadeFormClass ] ]
+    (
+      htmlAndSelectable.html
+      <> newSelect
+    )
+  where
+  htmlAndSelectable :: RenderAccum v
+  htmlAndSelectable =
+    F.foldl foldFn (initialAccum state)
+      $ Map.toList state.selected
+
+  foldFn :: RenderAccum v -> Tpl.Tuple Int (Option v) -> RenderAccum v
+  foldFn {selectable, html} (Tpl.Tuple inx opt) =
+    { html: html <> renderSelect inx opt selectable
+    , selectable: Set.delete opt selectable
+    }
+
+  renderSelect
+    :: Int -> Option v -> Set.Set (Option v) -> Array (ComponentHTML (Query v))
+  renderSelect inx selected choices =
+    [ H.div [ P.classes [ B.inputGroup, cascadeSelectClass ] ]
+      [
+        H.select [ P.classes [ B.formControl ]
+                 , E.onValueChange (E.input (Selected inx))
+                 ]
+        $ F.foldMap (oneOption $ M.Just selected)
+          $ L.sort $ Set.toList choices
+      , H.div [ P.classes [ B.inputGroupBtn ] ]
+        [
+          H.button [ E.onClick (E.input_ (Remove inx))
+                   , P.buttonType P.ButtonButton
+                   , P.classes [ B.btn, B.btnDefault ]
+                   ]
+          [ H.i [ P.classes [ B.glyphicon, B.glyphiconRemove ] ] [ ] ]
+        ]
+      ]
+    ]
+
+  oneOption :: M.Maybe (Option v) -> Option v -> Array (ComponentHTML (Query v))
+  oneOption mbSelected (Option choice) =
+    let
+      isSelected =
+        mbSelected
+          <#> runOption
+          <#> _.key
+          <#> eq choice.key
+          # M.fromMaybe false
+    in
+      [ H.option [ P.selected isSelected ]
+        [ H.text $ runSelectKey choice.key ]
+      ]
+
+  newSelect :: Array (ComponentHTML (Query v))
+  newSelect =
+    guard (not $ Set.isEmpty htmlAndSelectable.selectable)
+    $> (H.select [ E.onValueChange (E.input (Selected nextInx))
+                 , P.classes [ B.formControl, cascadeNewSelectClass ]
+                 ]
+        $ [ H.option_ [H.text cfg.inviteMessage ] ]
+        <> (F.foldMap (oneOption M.Nothing)
+              $ L.sort $ Set.toList htmlAndSelectable.selectable))
+
+  nextInx :: Int
+  nextInx =
+    M.fromMaybe zero $ add one $ F.maximum $ Map.keys state.selected
+
+
+eval :: forall v e. Natural (Query v) (CascadeSelectDSL v e)
+eval (Selected inx str next) = do
+  state <- get
+  F.for_ (Map.lookup (SelectKey str) state.keyMap) \opt -> do
+    modify (_selected %~
+            Map.fromList
+            <<< F.foldMap (\tpl -> guard (tpl # Tpl.snd # eq opt # not) $> tpl)
+            <<< Map.toList
+            )
+    modify (_selected %~ Map.insert inx opt)
+  pure next
+eval (Remove inx next) =
+  modify (_selected %~ Map.delete inx) $> next
+eval (GetSelected continue) =
+  gets
+    $ _.selected
+    >>> Map.values
+    >>> F.foldMap (runOption >>> _.value >>> pure)
+    >>> continue


### PR DESCRIPTION
Fixes https://slamdata.atlassian.net/browse/SD-1399

With following css

``` css
form.cascade-form {
  width: 600px;
  position: relative;
  left: 50%;
  margin-left: -300px;
  top: 40px;
}
form.cascade-form .cascade-new-select {
  margin-top: 6px;
}
form.cascade-form .cascade-select {
  margin-top: 3px;
}
```

And install code 

``` purescript
import SlamData.Halogen.Select.Cascade.Component as P
main  = do
  runAff throwException (const (pure unit)) do
    halogen <-
      runUI (P.cascadeSelect {inviteMessage: pure "Hello"})
        $ P.initialState [ "foo", "bar", "baz" ] P.SelectKey
    onLoad (appendToBody halogen.node)
```

This looks like 
![cascade](https://cloud.githubusercontent.com/assets/10245930/13427733/14644d38-dfc7-11e5-92f3-10a4628492c6.gif)

I don't like dependency on `halogen-bootstrap` but without it styling becomes too complicated. Probably config should work like `jtable`'s config and allows to specify subrenderers. I'll make another pr with some fixes for rotary selector and soon and some tweaks for this component soon (I'm not sure if it's convenient). 

@garyb please, review
