### PR TITLE
rotary selector margin fix

### DIFF
--- a/src/SlamData/Halogen/Select/Rotary/Component.purs
+++ b/src/SlamData/Halogen/Select/Rotary/Component.purs
@@ -1,6 +1,7 @@
 module SlamData.Halogen.Select.Rotary.Component
   (
     rotarySelect
+  , RotarySelectorConfig()
   , module SlamData.Halogen.Select.Rotary.Component.State
   , module SlamData.Halogen.Select.Rotary.Component.Query
   ) where
@@ -234,18 +235,18 @@ eval cfg (Init el next) = do
     let visibleCount = M.fromMaybe 2.0 cfg.visibleItemCount
     (wrapperSelector key) ? do
       width $ px $ visibleCount * cfg.itemWidth
-      marginLeft $ px (-1.0 * visibleCount * cfg.itemWidth * 0.5)
       overflow hidden
       position relative
     (draggedSelector key) ? do
       let
         iwidth = Int.floor cfg.itemWidth
         ilen = Cr.lengthCircular state.items
-        itemsOnScreen = screenWidth / iwidth + one
+        itemsOnScreen =
+          screenWidth / iwidth + one
         draggedWidth =
           cfg.itemWidth * Int.toNumber (itemsOnScreen * draggableScreens)
         itemsOnLeftSideCount =
-          draggableScreens * (itemsOnScreen / 2 / ilen)
+          draggableScreens * (itemsOnScreen / 2 / ilen + one)
         halfWidth =
           cfg.itemWidth * Int.toNumber (ilen * itemsOnLeftSideCount)
         leftPosition =

--- a/src/SlamData/Halogen/Select/Rotary/Component/State.purs
+++ b/src/SlamData/Halogen/Select/Rotary/Component/State.purs
@@ -4,7 +4,6 @@ import Prelude
 
 import Data.Maybe as M
 import Data.Lens (LensP(), lens)
-import Data.ExistsR as Er
 import Data.NonEmpty (NonEmpty())
 import Data.Circular as Cr
 


### PR DESCRIPTION
This fixes rotary selector behaviour (previously it used to set `marginLeft: 0px` sometimes) and remove one warning. 
